### PR TITLE
Restore functionality to publish documentation to application endpoint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Or the Gradle Wrapper:
 $ ./gradlew build bootRun
 ```
 
-Then access the app via a browser (or curl) on http://localhost:8080 to see the docs.
+Then access the app via a browser (or curl) on http://localhost:8080/html5/index.html to see the docs.
 
 ** It is very important to note that the project must be built before trying to run the project. Otherwise, the docs will not show up! **
 

--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,7 @@ test {
 
 asciidoctor {
     inputs.dir snippetsDir
+    outputDir "$projectDir/src/main/resources/public"
     dependsOn test
 }
 


### PR DESCRIPTION
Send asciidoctor output to project's public resources. 
Provide more specific generated documentation URL in readme.